### PR TITLE
Better support for structs and maps

### DIFF
--- a/Syntaxes/Elixir.xml
+++ b/Syntaxes/Elixir.xml
@@ -31,7 +31,6 @@
 	</comments>
 	
 	<brackets>
-		<pair open="%{" close="}" />
 		<pair open="{" close="}" />
 		<pair open="[" close="]" />
 		<pair open="(" close=")" />
@@ -39,7 +38,6 @@
 	</brackets>
 	
 	<surrounding-pairs>
-		<pair open="%{" close="}" />
 		<pair open="{" close="}" />
 		<pair open="[" close="]" />
 		<pair open="(" close=")" />

--- a/Syntaxes/Elixir.xml
+++ b/Syntaxes/Elixir.xml
@@ -500,6 +500,27 @@
 					<include syntax="self" collection="syntax" />
 				</subscopes>
 			</scope>
+						
+			<scope name="elixir.value.struct">
+				<symbol type="struct">
+					<context behavior="subtree" />
+				</symbol>
+				<starts-with>
+					<expression>(\%[\w_]+)(\{)</expression>
+					<capture number="1" name="elixir.struct.identifier" />
+					<capture number="2" name="elixir.bracket" />
+				</starts-with>
+				<ends-with>
+					<expression>\}</expression>
+					<capture number="0" name="elixir.bracket" />
+				</ends-with>
+				<subscopes>
+					<include syntax="self" collection="comments" />
+					<include syntax="self" collection="values" />
+					<include syntax="self" collection="identifiers" />
+					<include syntax="self" collection="syntax" />
+				</subscopes>
+			</scope>
 		</collection>
 		
 		<!-- Strings -->

--- a/Syntaxes/Elixir.xml
+++ b/Syntaxes/Elixir.xml
@@ -482,7 +482,7 @@
 			</scope>
 			
 			<scope name="elixir.value.map">
-				<symbol type="expression">
+				<symbol type="struct">
 					<context behavior="subtree" />
 				</symbol>
 				<starts-with>


### PR DESCRIPTION
Just a starting place for now. I asked Panic what the odds were that they'd be willing to release their syntax grammar for Typescript as complete example. I feel like there would be some instructive definitions in there.

Anyway, I think that perhaps map should technically be adjusted slightly as well, but I am not enough of a language nerd to know if Elixir's `map` is an example of a "struct" as far as [these docs](https://docs.nova.app/api-reference/symbol/#type) are concerned... so your call on if you want me to nix that last commit.